### PR TITLE
Implementação de log remoto.

### DIFF
--- a/App.js
+++ b/App.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { createAppContainer } from 'react-navigation';
 import { LogBox } from 'react-native';
 import firebase from 'firebase';
+import Logs from './src/logs/log';
 import MainNavigation from './src/navigation/MainNavigation';
 import { Provider as AuthProvider } from './src/context/AuthContext';
 import { Provider as UserProvider } from './src/context/UserContext';

--- a/app.json
+++ b/app.json
@@ -2,11 +2,7 @@
   "expo": {
     "name": "cestas",
     "slug": "cestas",
-    "platforms": [
-      "ios",
-      "android",
-      "web"
-    ],
+    "platforms": ["ios", "android", "web"],
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
@@ -18,11 +14,21 @@
     "updates": {
       "fallbackToCacheTimeout": 0
     },
-    "assetBundlePatterns": [
-      "**/*"
-    ],
+    "assetBundlePatterns": ["**/*"],
     "ios": {
       "supportsTablet": true
+    },
+    "hooks": {
+      "postPublish": [
+        {
+          "file": "sentry-expo/upload-sourcemaps",
+          "config": {
+            "organization": "ifsp-fn",
+            "project": "cestas-cooperflora",
+            "authToken": "8ea6a44bf50f44669fd2911ba93b5699aa97f7d586f44b0c9ed1ce85b267389b"
+          }
+        }
+      ]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,8 +19,12 @@
     "axios": "^0.19.2",
     "date-fns": "^2.16.1",
     "expo": "^42.0.0",
+    "expo-application": "^3.2.0",
+    "expo-constants": "^11.0.1",
+    "expo-device": "^3.3.0",
     "expo-document-picker": "^9.2.4",
     "expo-image-picker": "^10.2.3",
+    "expo-updates": "^0.8.5",
     "firebase": "8.2.3",
     "react": "16.13.1",
     "react-dom": "16.13.1",
@@ -44,7 +48,8 @@
     "react-navigation": "^4.3.9",
     "react-navigation-material-bottom-tabs": "^2.2.12",
     "react-navigation-stack": "^2.7.0",
-    "react-navigation-tabs": "^2.8.13"
+    "react-navigation-tabs": "^2.8.13",
+    "sentry-expo": "^4.0.1"
   },
   "devDependencies": {
     "@babel/core": "~7.9.0",


### PR DESCRIPTION
Analisei três ferramentas: Bugfender, Logrocket e Sentry. As duas primeiras não trabalham com app Expo. Dessa forma instalei a última. 